### PR TITLE
Actually fix #13

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/common/tiles/TileItemOutputBus.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/tiles/TileItemOutputBus.java
@@ -84,6 +84,10 @@ public class TileItemOutputBus extends TileItemBus implements MachineComponentTi
 
                 if (externalStack == ItemStack.EMPTY) {
                     ItemStack notInserted = external.insertItem(externalSlotId, internalStack, false);
+                    // Safeguard against Storage Drawers virtual slot
+                    if (notInserted.getCount() == internalStack.getCount()) {
+                        break;
+                    }
                     inventory.setStackInSlot(internalSlotId, notInserted);
                     successAtLeastOnce = true;
                     if (notInserted == ItemStack.EMPTY) {
@@ -99,9 +103,6 @@ public class TileItemOutputBus extends TileItemBus implements MachineComponentTi
                 // Extract internal item to external.
                 ItemStack notInserted = external.insertItem(externalSlotId, internalStack, false);
                 inventory.setStackInSlot(internalSlotId, notInserted);
-                if (notInserted.getCount() == internalStack.getCount()) {
-                    break;
-                }
 
                 successAtLeastOnce = true;
                 if (notInserted == ItemStack.EMPTY) {


### PR DESCRIPTION
Issue #13 still exists in r32, sorry I should have clarified a bit more. The check for `notInserted.getCount() == internalStack.getCount()` has to be within the `if (externalStack == ItemStack.EMPTY)` block because when the hatch is checking the virtual slot, the slot always returns `ItemStack.EMPTY` for `getStackInSlot` as seen [here](https://github.com/jaquadro/StorageDrawers/blob/1.12/src/com/jaquadro/minecraft/storagedrawers/capabilities/DrawerItemHandler.java#L33).